### PR TITLE
Add user avatar to overall_stats

### DIFF
--- a/owapi/routes.py
+++ b/owapi/routes.py
@@ -80,6 +80,9 @@ async def bl_get_compstats(ctx: HTTPRequestContext, battletag: str):
     else:
         comprank = None
     built_dict["overall_stats"]["comprank"] = comprank
+    
+    # Fetch Avatar
+    built_dict["overall_stats"]["avatar"] = parsed.find(".//img[@class='player-portrait']").attrib['src']
 
     hascompstats = parsed.xpath(".//div[@data-group-id='stats' and @data-category-id='0x02E00000FFFFFFFF']")
     if len(hascompstats) != 2:

--- a/owapi/routes.py
+++ b/owapi/routes.py
@@ -177,6 +177,9 @@ async def bl_get_stats(ctx: HTTPRequestContext, battletag: str):
     else:
         comprank = None
     built_dict["overall_stats"]["comprank"] = comprank
+    
+    # Fetch Avatar
+    built_dict["overall_stats"]["avatar"] = parsed.find(".//img[@class='player-portrait']").attrib['src']
 
     stat_groups = parsed.xpath(".//div[@data-group-id='stats' and @data-category-id='0x02E00000FFFFFFFF']")[0]
     # Highlight specific stat groups.


### PR DESCRIPTION
Adds the users avatar to overall_stats, Implements #23 

Don't know if this is the best way either, i've literally never used lxml before a few days ago (or Python for that matter)

**NOTE** I have not tested if this works with this repo, I have my own version of this API that I've remade in Python 2.7 and it works there.