### PR TITLE
Improved install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ OWAPI has a few requirements:
  4. **Install the requirements.**
 
      For debian-based systems:
-        `sudo apt install libxslt-dev python3-dev build-essential`
+        `sudo apt install libxslt-dev python3-dev build-essential zlib1g-dev`
 
-     `source ./venv/activate && pip install -r requirements.txt`
+     `source ./venv/bin/activate && pip install wheel && pip install -r requirements.txt`
      
  5. **Start the OWAPI server.**
  
      `PYTHONPATH=. asphalt run config.yml`
+     
+     The server is now running on http://localhost:4444/
           
      Note: If you want the full speedups from Kyoukai you must run with uvloop enabled:
      `PYTHONPATH=. asphalt run -l uvloop config.yml`


### PR DESCRIPTION
I recently tried to run OWAPI on a completely fresh ubuntu vm and ran into some problems. They were easy enough to fix with some basic troubleshooting, but should be covered by the install instructions.

The 4 changes I made:

* install xlib1g-dev with apt
* install wheel with pip (apparently a prerequisite to build some of the pip packages)
* activate the virtual environment with `./venv/bin/activate` instead of `./venv/activate`.
* mention that the server is running on port 4444, not 80 like the official server