### PR TITLE
Add option for pretty-printed json output

### DIFF
--- a/owapi/app.py
+++ b/owapi/app.py
@@ -86,7 +86,10 @@ async def jsonify(ctx, response: Response):
     status_code = response.code
     if not any(response.body.values()):
         status_code = 404
-    d = json.dumps(response.body)
+    if ctx.request.args.get("format", "json") == "json_pretty":
+        d = json.dumps(response.body, sort_keys=True, indent=4, separators=(',', ': '))
+    else:
+        d = json.dumps(response.body)
     response.body = d
     response.headers["Content-Type"] = "application/json"
     response.code = status_code


### PR DESCRIPTION
This introduces the new url parameter format. 

https://owapi.net/api/v3/u/SunDwarf-21353/blob?format=json is the default and continues to behave the same as https://owapi.net/api/v3/u/SunDwarf-21353/blob

https://owapi.net/api/v3/u/SunDwarf-21353/blob?format=json_pretty formats the returned json in a more human readable format, with proper indentation. This makes any kind of debugging or visual inspection a lot easier.

This affects both v2 and v3, but not the error handlers (their responses are short enough that it's not really worth the code complexity)

I didn't make pretty-printing the default because it adds significant runtime overhead (formating a v3/blob output with json_pretty adds about 10% to the cpu time compared to plain json formatting).