### PR TITLE
replace manual name sanitation with util.sanitize_string

### DIFF
--- a/owapi/util.py
+++ b/owapi/util.py
@@ -134,4 +134,5 @@ def sanitize_string(string):
     """
     space_converted = re.sub(r'[-\s]', '_', unidecode.unidecode(string).lower())
     removed_nonalphanumeric = re.sub(r'\W', '', space_converted)
-    return re.sub(r'_{2,}', '_', removed_nonalphanumeric)
+    underscore_normalized = re.sub(r'_{2,}', '_', removed_nonalphanumeric)
+    return underscore_normalized.replace("soldier_76", "soldier76") #backwards compatability

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -126,7 +126,7 @@ def bl_parse_stats(parsed, mode="quickplay"):
         trs = subbox.findall(".//tbody/tr")
         # Update the dict with [0]: [1]
         for subval in trs:
-            name, value = subval[0].text.lower().replace(" ", "_").replace("_-_", "_"), subval[1].text
+            name, value = util.sanitize_string(subval[0].text), subval[1].text
             # Try and parse out the value. It might be a time!
             # If so, try and extract the time.
             nvl = util.try_extract(value)
@@ -160,10 +160,7 @@ def bl_parse_all_heroes(parsed, mode="quickplay"):
     # Loop over each one, extracting the name and hours counted.
     for child in hero_info:
         name, played = child.getchildren()
-        name, played = name.text.lower(), played.text.lower()
-
-        name = unidecode.unidecode(name)
-        name = name.replace(".", "").replace(": ", "")  # d.va and soldier: 76 special cases
+        name, played = util.sanitize_string(name.text), played.text.lower()
 
         if played == "--":
             time = 0
@@ -200,12 +197,12 @@ def bl_parse_hero_data(parsed: etree._Element, mode="quickplay"):
         trs = hero_specific_box.findall(".//tbody/tr")
         # Update the dict with [0]: [1]
         for subval in trs:
-            name, value = subval[0].text, subval[1].text
+            name, value = util.sanitize_string(subval[0].text), subval[1].text
             if 'average' in name.lower():
                 # No averages, ty
                 continue
             nvl = util.try_extract(value)
-            _t_d[name.lower().replace(" ", "_").replace("_-_", "_")] = nvl
+            _t_d[name] = nvl
 
         n_dict["hero_stats"] = _t_d
 
@@ -214,12 +211,12 @@ def bl_parse_hero_data(parsed: etree._Element, mode="quickplay"):
             trs = subbox.findall(".//tbody/tr")
             # Update the dict with [0]: [1]
             for subval in trs:
-                name, value = subval[0].text, subval[1].text
+                name, value = util.sanitize_string(subval[0].text), subval[1].text
                 if 'average' in name.lower():
                     # No averages, ty
                     continue
                 nvl = util.int_or_string(value)
-                _t_d[name.lower().replace(" ", "_").replace("_-_", "_")] = nvl
+                _t_d[name] = nvl
 
         n_dict["general_stats"] = _t_d
 


### PR DESCRIPTION
So far the code used a number of rules for sanitizing keys to produce pretty ascii-lowercase keys without punctuation. At each individual place where this was needed, a different set of rules was applied to produce the required result. #87 introduced the function util.sanitize_string() to solve this problem in a more generic way. This commit replaces all individual rules with util.sanitize_string().

This produces the same output, except for the hero stats "torbjorn_kills" and "torborn_kills_most_in_game", which before this commit are reported as "torbj\u00f6rn_kills" and "torbj\u00f6rn_kills_most_in_game" (while any other instance of torbjörn is output as tobjorn). That bug is what motivated this PR.

Note that this is a breaking change, since the two previously mentioned keys are changed.