### PR TITLE
Properly parse time in general_stats for each hero

### DIFF
--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -215,7 +215,7 @@ def bl_parse_hero_data(parsed: etree._Element, mode="quickplay"):
                 if 'average' in name.lower():
                     # No averages, ty
                     continue
-                nvl = util.int_or_string(value)
+                nvl = util.try_extract(value)
                 _t_d[name] = nvl
 
         n_dict["general_stats"] = _t_d


### PR DESCRIPTION
Currently time amounts are being parsed into floating point values everywhere but in the hero stats.

For example:

```json
"stats": {
  "competitive": {
    "d.va": {
      "general_stats": {
        "objective_time": "39:31",
        "objective_time_most_in_game": "05:19",
```

This changes parsing to parse time values in all cases, resulting in

```json
"stats": {
  "competitive": {
    "d.va": {
      "general_stats": {
        "objective_time": 0.6586111111111111,
         "objective_time_most_in_game": 0.08861111111111111,
```

which is consistent with the parsing of all other categories.

This is a breaking change, but I guess anybody who depends on this would have already complained about the lack of parsing?