### PR TITLE
parse percentages as float

### DIFF
--- a/owapi/util.py
+++ b/owapi/util.py
@@ -14,6 +14,7 @@ logger = logging.getLogger("OWAPI")
 HOUR_REGEX = re.compile(r"([0-9]*) hours?")
 MINUTE_REGEX = re.compile(r"([0-9]*) minutes?")
 SECOND_REGEX = re.compile(r"([0-9]*) seconds?")
+PERCENT_REGEX = re.compile(r"([0-9]{1,3})\s?\%")
 
 async def with_cache(ctx: HTTPRequestContext, func, *args, expires=300, cache_404=False):
     """
@@ -103,6 +104,14 @@ def try_extract(value):
         val = matched.groups()[0]
         val = float(val)
         val = (val / 60 / 60)
+
+        return val
+
+    matched = PERCENT_REGEX.match(value)
+    if matched:
+        val = matched.groups()[0]
+        val = float(val)
+        val = (val / 100)
 
         return val
 


### PR DESCRIPTION
This one could be called "personal preference" or even "breaking compatability for no good reason", but since it's a change I will be running locally I thought I should at least throw it out there:

All values returned by the API are parsed as floats (or ints), with only three exceptions: urls, achievements (which are boolean) and percentage value. Since mathematically, "50%" == 0.5, it seems more consistent to me to parse percentage values as float. This leads to entire sections, like the hero stats, to become a collection of float values.

As a concrete example, this change changes

```json
"stats": {
  "competitive": {
    "d.va": {
      "general_stats": {
        "teleporter_pads_destroyed": 3.0,
        "time_played": 3.0,
        "weapon_accuracy_best_in_game": "66%",
        "win_percentage": "41%"
```

to

```json
"stats": {
  "competitive": {
    "d.va": {
      "general_stats": {
        "teleporter_pads_destroyed": 3.0,
        "time_played": 3.0,
        "weapon_accuracy_best_in_game": 0.66,
        "win_percentage": 0.41
```

Note that I have left the manually computed overall quickplay/competitive win_rate alone in an effort to break less stuff, meaning that it is still reported as an integer between 0 and 100. But that value was never formatted consistently with other pecentage values like a hero's win_percentage, and is currently broken for quickplay anyways.