### PR TITLE
add option to remove redis dependency

### DIFF
--- a/config_noredis.yaml
+++ b/config_noredis.yaml
@@ -1,0 +1,8 @@
+---
+component:
+  type: owapi.app:APIComponent
+  use_redis: False
+  components:
+    kyoukai:
+      app: owapi.app:app
+      debug: True

--- a/owapi/app.py
+++ b/owapi/app.py
@@ -6,7 +6,6 @@ import logging
 import traceback
 
 from asphalt.core import ContainerComponent
-from asphalt.redis.component import RedisComponent
 from kyoukai import Blueprint
 from kyoukai import HTTPException
 from kyoukai import Kyoukai
@@ -35,11 +34,18 @@ class APIComponent(ContainerComponent):
     """
     Container for other components. I think.
     """
+    def __init__(self, components, use_redis = True):
+        super().__init__(components)
+        app.config["owapi_use_redis"] = use_redis
 
     async def start(self, ctx):
         self.add_component('kyoukai', KyoukaiComponent, ip="127.0.0.1", port=4444,
                            app="app:app", template_renderer=None)
-        self.add_component('redis', RedisComponent)
+        if app.config["owapi_use_redis"]:
+            from asphalt.redis.component import RedisComponent
+            self.add_component('redis', RedisComponent)
+        else:
+            logger.warn('redis is disabled by config, rate limiting and caching not available')
         await super().start(ctx)
 
         logger.info("Started OWAPI server.")

--- a/owapi/util.py
+++ b/owapi/util.py
@@ -23,7 +23,7 @@ async def with_cache(ctx: HTTPRequestContext, func, *args, expires=300, cache_40
     Unless we don have redis.
     """
 
-    if not ctx._app.config["owapi_use_redis"]:
+    if not ctx.app.config["owapi_use_redis"]:
         #no caching without redis, just call the function
         logger.info("Loading `{}` with disabled cache".format(repr(args)))
         result = await func(ctx, *args)

--- a/owapi/v3/v3_util.py
+++ b/owapi/v3/v3_util.py
@@ -63,7 +63,7 @@ def with_ratelimit(bucket: str, timelimit: int=None, max_reqs: int=0):
 
             # only ratelimit if we have redis. Can't make this decision in
             # outer functions because they are called before globalsettings are set
-            if ctx._app.config["owapi_use_redis"]:
+            if ctx.app.config["owapi_use_redis"]:
                 import aioredis
                 assert isinstance(ctx.redis, aioredis.Redis)
                 # Get the IP.


### PR DESCRIPTION
When running a local instance and querying the v3/blob api, caching outbound requests becomes a lot less useful. Ratelimiting is also pointless if you are the only consumer. Deactivating both features means you no longer need redis.

This commit adds a config file flag use_redis (which defaults to true). When set to true, everything behaves as before. When set to false, ratelimiting and caching are disabled, redis is not set up and no redis libraries are imported.