### PR TITLE
Doc: Added pkg-config to required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ OWAPI has a few requirements:
  4. **Install the requirements.**
 
      For debian-based systems:
-        `sudo apt install libxslt-dev python3-dev build-essential zlib1g-dev`
+        `sudo apt install libxslt-dev python3-dev build-essential zlib1g-dev pkg-config`
 
      `source ./venv/bin/activate && pip install wheel && pip install -r requirements.txt`
 


### PR DESCRIPTION
Without pkg-config, I get this error:

```
Collecting html5_parser==0.3.3 (from -r requirements.txt (line 8))
  Downloading html5-parser-0.3.3.tar.gz (250kB)
    100% |████████████████████████████████| 256kB 4.2MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-ugvxg2ti/html5-parser/setup.py", line 79, in <module>
        include_dirs=include_dirs(),
      File "/tmp/pip-build-ugvxg2ti/html5-parser/build.py", line 89, in include_dirs
        return [x[2:] for x in pkg_config('libxml-2.0', '--cflags-only-I')]
      File "/tmp/pip-build-ugvxg2ti/html5-parser/build.py", line 75, in pkg_config
        val = subprocess.check_output([PKGCONFIG, pkg] + list(args)).decode('utf-8')
      File "/usr/lib/python3.5/subprocess.py", line 626, in check_output
        **kwargs).stdout
      File "/usr/lib/python3.5/subprocess.py", line 693, in run
        with Popen(*popenargs, **kwargs) as process:
      File "/usr/lib/python3.5/subprocess.py", line 947, in __init__
        restore_signals, start_new_session)
      File "/usr/lib/python3.5/subprocess.py", line 1551, in _execute_child
        raise child_exception_type(errno_num, err_msg)
    FileNotFoundError: [Errno 2] No such file or directory: 'pkg-config'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-ugvxg2ti/html5-parser/
```