### PR TITLE
Require 2.2.x of aiohttp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Kyoukai>=2.1.4,<=2.3.0
 aioredis>=0.3.0,<=1.0.0
-aiohttp>=2.2.0,<=2.3.0
+aiohttp>=2.2.0,<=2.2.5
 asphalt==4.0.0
 asphalt-redis==2.0.1
 asyncio-extras>=1.3.0,<=1.4.0


### PR DESCRIPTION
2.3 changed the paramter of the init Client class.

See here: https://github.com/aio-libs/aiohttp/pull/2256/files

Error w/ 2.3

```
AttributeError("module 'aiohttp' has no attribute 'proxies_from_env'",)
```